### PR TITLE
Copy swizzle values for Switch

### DIFF
--- a/BfresLibrary/Shared/ResFile.cs
+++ b/BfresLibrary/Shared/ResFile.cs
@@ -458,6 +458,9 @@ namespace BfresLibrary
                     anim.Name = $"{anim.Name}_ftp";
                 }
 
+                // Workaround for Null "MatVisibilityAnims" variable
+                if (MatVisibilityAnims == null)
+                    MatVisibilityAnims = new ResDict<MaterialAnim>();
                 foreach (var anim in MatVisibilityAnims.Values) {
                     anim.Name = $"{anim.Name}_fvs";
                 }

--- a/BfresLibrary/Switch/Texture/Texture.cs
+++ b/BfresLibrary/Switch/Texture/Texture.cs
@@ -89,6 +89,7 @@ namespace BfresLibrary.Switch
             Texture.Format = PlatformConverters.TextureConverter.FormatList[textureU.Format];
             Texture.Name = textureU.Name;
             Texture.AccessFlags = AccessFlags.Texture;
+            Texture.Swizzle = textureU.SwizzlePattern;
 
             //Save arrays and mips into a list for swizzling back
             Texture.TextureData = new List<List<byte[]>>();


### PR DESCRIPTION
Copy swizzle values from Wii U textures to Switch.
Fixed a null reference exception.