### PR TITLE
Changed FBVS to FVIS

### DIFF
--- a/BfresLibrary/Shared/VisibilityAnim/VisibilityAnim.cs
+++ b/BfresLibrary/Shared/VisibilityAnim/VisibilityAnim.cs
@@ -33,7 +33,7 @@ namespace BfresLibrary
 
         // ---- CONSTANTS ----------------------------------------------------------------------------------------------
 
-        private const string _signature = "FBVS";
+        private const string _signature = "FVIS";
 
         private const ushort _flagsMask = 0b00000000_00000111;
         private const ushort _flagsMaskType = 0b00000001_00000000;


### PR DESCRIPTION
The signature for Visibilty Anims was incorrectly listed as FBVS instead of FVIS