### PR TITLE
README.md: Fix LICENSE link (LICENS -> LICENSE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ A reworked version of NintenTools.Bfres with Wii U and Switch support and many v
 
 ## LICENSE
 
-https://gitlab.com/Syroot/NintenTools.Bfres/-/blob/master/LICENS
+https://gitlab.com/Syroot/NintenTools.Bfres/-/blob/master/LICENSE


### PR DESCRIPTION
Changed from [LICENS](https://gitlab.com/Syroot/NintenTools.Bfres/-/blob/master/LICENSE) to [LICENSE](https://gitlab.com/Syroot/NintenTools.Bfres/-/blob/master/LICENSE)
